### PR TITLE
 Add dark mode support for warning message

### DIFF
--- a/persistent_login.css
+++ b/persistent_login.css
@@ -27,3 +27,8 @@
 	text-align: center;
 	text-shadow: none;
 }
+
+html.dark-mode .ifpl-hint {
+        background: none;
+        color: #f00;
+}


### PR DESCRIPTION
Removes background and ups saturation of text for dark mode
![image](https://user-images.githubusercontent.com/9071443/228825858-ff0b31c3-44d6-465d-92e4-99ed1373c0c4.png)
